### PR TITLE
RHEL & Hostname/Port Override Update

### DIFF
--- a/ibm-ace/README.md
+++ b/ibm-ace/README.md
@@ -36,7 +36,43 @@ To deploy a production IBM App Connect Enterprise integration server, [check the
   * runAsNonRoot: false
   * runAsUser: 0
   * privileged: false
+  
+* On RedHat OpenShift a [Security Context Constraint](https://blog.openshift.com/understanding-service-accounts-sccs/) should be used in place of a pod security policy. The recommended Security Context Constraint is shown below:
+```
+kind: SecurityContextConstraints
+apiVersion: v1
+metadata:
+  name: ibm-ace-scc
+allowPrivilegedContainer: true
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+fsGroup:
+  type: RunAsAny
+supplementalGroups:
+  type: RunAsAny
+requiredDropCapabilities:
+- MKNOD
+allowedCapabilities:
+- SETPCAP
+- AUDIT_WRITE
+- CHOWN
+- NET_RAW
+- DAC_OVERRIDE
+- FOWNER
+- FSETID
+- KILL
+- SETUID
+- SETGID
+- NET_BIND_SERVICE
+- SYS_CHROOT
+- SETFCAP  
+forbiddenSysctls:
+- '*'    
+```
 * **Note**: If you are deploying to an IBM Cloud Private environment that does not support these security settings by default. Follow these [instructions](https://www.ibm.com/support/knowledgecenter/SSBS6K_3.1.0/app_center/nd_helm.html) to enable your deployment.
+
 * If you are using SELinux you must meet the [MQ requirements](https://www-01.ibm.com/support/docview.wss?uid=swg21714191)
 
 ## Resources Required
@@ -180,6 +216,7 @@ The following table lists the configurable parameters of the `ibm-ace` chart and
 | `service.webuiPort`              | Web UI port number - read only                  | `7600`                                                     |
 | `service.serverlistenerPort`     | Http server listener port number - read only    | `7800`                                                     |
 | `service.serverlistenerTLSPort`  | Https server listener port number - read only   | `7843`                                                     |
+| `service.iP`                     | This is a hostname/IP that the nodeport is connected to i.e. a workers IP    | `mycluster.icp`               |
 | `aceonly.resources.limits.cpu`        | Kubernetes CPU limit for the container      | `1`                                                       |
 | `aceonly.resources.limits.memory`     | Kubernetes memory limit for the container   | `1024Mi`                                                  |
 | `aceonly.resources.requests.cpu`      | Kubernetes CPU request for the container    | `1`                                                       |

--- a/ibm-ace/templates/deployment.yaml
+++ b/ibm-ace/templates/deployment.yaml
@@ -69,6 +69,7 @@ spec:
                 operator: In
                 values:
                 - {{ .Values.arch }}
+      serviceAccountName: {{ include "fullname" . }}
       {{- if .Values.image.pullSecret }}
       imagePullSecrets:
         - name: {{ .Values.image.pullSecret }}
@@ -98,10 +99,14 @@ spec:
               value: "false"
             - name: ACE_SERVER_NAME
               value: {{ print $serverName | quote }}
+            - name: SERVICE_NAME
+              value: {{ include "fullname" . }}
             - name: LOG_FORMAT
               value: {{ .Values.log.format | default "json" | quote }}
             - name: ACE_ENABLE_METRICS
               value: {{ .Values.metrics.enabled | default true | quote }}
+            - name: MQSI_OVERRIDE_HOSTNAME
+              value: {{ .Values.service.iP }}
             {{- if and .Values.integrationServer.keystore .Values.integrationServer.keystore.password }}
             - name: "ACE_KEYSTORE_PASSWORD"
               valueFrom:

--- a/ibm-ace/templates/server-rb.yaml
+++ b/ibm-ace/templates/server-rb.yaml
@@ -1,0 +1,35 @@
+# © Copyright IBM Corporation 2018
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+###############################################################################
+# Creates a role binding between the server role and the server service
+# account
+###############################################################################
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "fullname" . }}
+  labels:
+    app: {{ .Chart.Name }}
+    chart: {{ .Chart.Name }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "fullname" . }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  apiGroup: rbac.authorization.k8s.io
+  name: {{ include "fullname" . }}

--- a/ibm-ace/templates/server-role.yaml
+++ b/ibm-ace/templates/server-role.yaml
@@ -1,0 +1,30 @@
+# © Copyright IBM Corporation 2018
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+###############################################################################
+# Creates a role that can list services
+###############################################################################
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "fullname" . }}
+  labels:
+    app: {{ .Chart.Name }}
+    chart: {{ .Chart.Name }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+rules:
+- apiGroups: [""] # "" indicates the core API group
+  resources: ["services"]
+  verbs: ["get","list"]

--- a/ibm-ace/templates/server-sa.yaml
+++ b/ibm-ace/templates/server-sa.yaml
@@ -1,0 +1,28 @@
+# © Copyright IBM Corporation 2018
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+###############################################################################
+# Creates a service account for the server to use to access
+# resources information
+###############################################################################
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: {{ .Chart.Name }}
+    chart: {{ .Chart.Name }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  name: {{ include "fullname" . }}
+  namespace: {{ .Release.Namespace }}

--- a/ibm-ace/templates/stateful-set.yaml
+++ b/ibm-ace/templates/stateful-set.yaml
@@ -73,6 +73,7 @@ spec:
                 operator: In
                 values:
                 - {{ .Values.arch }}
+      serviceAccountName: {{ include "fullname" . }}
       {{- if .Values.image.pullSecret }}
       imagePullSecrets:
         - name: {{ .Values.image.pullSecret }}
@@ -107,12 +108,16 @@ spec:
               value: {{ .Values.queueManager.name | default .Release.Name | replace "-" "" | quote }}
             - name: ACE_SERVER_NAME
               value: {{ print $serverName | quote }}
+            - name: SERVICE_NAME
+              value: {{ include "fullname" . }}
             - name: LOG_FORMAT
               value: {{ .Values.log.format | default "json" | quote }}
             - name: MQ_ENABLE_METRICS
               value: {{ .Values.metrics.enabled | default true | quote }}
             - name: ACE_ENABLE_METRICS
               value: {{ .Values.metrics.enabled | default true | quote }}
+            - name: MQSI_OVERRIDE_HOSTNAME
+              value: {{ .Values.service.iP }}
             {{- if and .Values.integrationServer.keystore .Values.integrationServer.keystore.password }}
             - name: "ACE_KEYSTORE_PASSWORD"
               valueFrom:
@@ -182,21 +187,22 @@ spec:
             runAsNonRoot: false
             runAsUser: 0
             privileged: false
-            capabilities:
-              add:
-              - SETPCAP
-              - AUDIT_WRITE
-              - CHOWN
-              - NET_RAW
-              - DAC_OVERRIDE
-              - FOWNER
-              - FSETID
-              - KILL
-              - SETUID
-              - SETGID
-              - NET_BIND_SERVICE
-              - SYS_CHROOT
-              - SETFCAP
+            # Uncommenting the following lines will enforce the capabilites to be present before the pod will start if you would like tighter control of the system security
+            # capabilities:
+            #  add:
+            #  - SETPCAP
+            #  - AUDIT_WRITE
+            #  - CHOWN
+            #  - NET_RAW
+            #  - DAC_OVERRIDE
+            #  - FOWNER
+            #  - FSETID
+            #  - KILL
+            #  - SETUID
+            #  - SETGID
+            #  - NET_BIND_SERVICE
+            #  - SYS_CHROOT
+            #  - SETFCAP
           # Set liveness probe to determine if the Integration Server is running
           livenessProbe:
             exec:

--- a/ibm-ace/values.yaml
+++ b/ibm-ace/values.yaml
@@ -35,7 +35,7 @@ image:
   # pullPolicy of IfNotPresent causes image pulling to be skipped if it already exists. Change to Always to force a pull.
   pullPolicy: IfNotPresent
   # pullSecret is the secret to use when pulling the image from a private registry
-  pullSecret:
+  pullSecret: 
 
 arch: amd64
 
@@ -63,6 +63,7 @@ service:
   webuiPort: 7600
   serverlistenerPort: 7800
   serverlistenerTLSPort: 7843
+  iP: mycluster.icp
 
 ###########################################################
 # ibm-ace-server (ACE only) specific settings


### PR DESCRIPTION
Updated with:

Core to generate RHEL based images
Fix to overriding the hostname and port for RestAPI in the UI / Swagger Docs.